### PR TITLE
Stop gem build warnings

### DIFF
--- a/c7decrypt.gemspec
+++ b/c7decrypt.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
              "README.md",
              "Rakefile",
              "c7decrypt.gemspec"]
+  s.license       = "ruby"
   s.require_paths = ["lib"]
   s.executables   = s.files.grep(%r{^bin/[^\/]+$}) { |f| File.basename(f) }
   s.summary = 'Ruby based Cisco Password Encryptor/Decryptor'
@@ -27,8 +28,8 @@ Gem::Specification.new do |s|
   s.cert_chain  = ['certs/claudijd.pem']
   s.signing_key = File.expand_path("~/.ssh/gem-private_key.pem") if $0 =~ /gem\z/
 
-  s.add_development_dependency('fuzzbert')
-  s.add_development_dependency('rspec', '~> 3.0.0')
-  s.add_development_dependency('rspec-its')
-  s.add_development_dependency('rake')
+  s.add_development_dependency('fuzzbert', '~> 1.0')
+  s.add_development_dependency('rspec', '~> 3.0')
+  s.add_development_dependency('rspec-its', '~> 1.2')
+  s.add_development_dependency('rake', '~> 10.3')
 end


### PR DESCRIPTION
Stops all these warnings that I had when trying to build c7decrypt for a demo...

WARNING:  licenses is empty, but is recommended.  Use a license abbreviation from:
http://opensource.org/licenses/alphabetical
WARNING:  open-ended dependency on fuzzbert (>= 0, development) is not recommended
  if fuzzbert is semantically versioned, use:
    add_development_dependency 'fuzzbert', '~> 0'
WARNING:  pessimistic dependency on rspec (~> 3.0.0, development) may be overly strict
  if rspec is semantically versioned, use:
    add_development_dependency 'rspec', '~> 3.0', '>= 3.0.0'
WARNING:  open-ended dependency on rspec-its (>= 0, development) is not recommended
  if rspec-its is semantically versioned, use:
    add_development_dependency 'rspec-its', '~> 0'
WARNING:  open-ended dependency on rake (>= 0, development) is not recommended
  if rake is semantically versioned, use:
    add_development_dependency 'rake', '~> 0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
Enter PEM pass phrase:
ERROR:  While executing gem ... (OpenSSL::PKey::RSAError)
    Neither PUB key nor PRIV key: nested asn1 error